### PR TITLE
Updated with new logic, ensures success for MP.

### DIFF
--- a/mp_name_fix.mod
+++ b/mp_name_fix.mod
@@ -1,4 +1,4 @@
-version="1.1"
+version="1.2"
 tags={
 	"Fixes"
 }

--- a/mp_name_fix/common/decisions/mpnf_decision.txt
+++ b/mp_name_fix/common/decisions/mpnf_decision.txt
@@ -1,33 +1,73 @@
-mpnf_decision = {
+mpnf_decision_save = {
     picture = { 
         reference = "gfx/interface/illustrations/decisions/decision_dynasty_house.dds" 
     }
 
-    desc = mpnf_decision_desc
+    desc = mpnf_decision_save_desc
 
     is_shown = {
         always = yes
     }
 
     effect = {
-        custom_tooltip = mpnf_decision_custom.tt 
+        custom_tooltip = mpnf_decision_save_custom_tt 
 
-        # set all house names to themselves
+        # store the result of GetName so it can be retreived from GetBaseName later.
+        # this must be done prior to player join for GetName to return anything but " "
         hidden_effect = {
             every_living_character = {
-                
-                save_scope_as = curr_char
-
-                set_global_variable = {
-                    name = temp_char
-                    value = scope:curr_char
-                }
-
+            
                 house = {
-                    set_house_name = "[GetGlobalVariable('temp_char').Char.GetDynastyHouseNameNoTooltip]"
+                    save_scope_as = curr_house
+
+                    set_global_variable = {
+                        name = temp_house
+                        value = scope:curr_house
+                    }
+
+                    set_house_name = "[GetGlobalVariable('temp_house').House.GetNameNoTooltip]"
+
+                    remove_global_variable = temp_house
+                }
+ 
+            }
+        }
+    }
+    ai_check_interval = 0
+}
+
+mpnf_decision_load = {
+    picture = { 
+        reference = "gfx/interface/illustrations/decisions/decision_dynasty_house.dds" 
+    }
+
+    desc = mpnf_decision_load_desc
+
+    is_shown = {
+        always = yes
+    }
+
+    effect = {
+        custom_tooltip = mpnf_decision_load_custom_tt 
+
+        # set the empty name of the House to the BaseName, which is not affected by player join
+        # this should be done after mpnf_decision_save has been taken and BaseNames have been updated 
+        hidden_effect = {
+            every_living_character = {
+            
+                house = {
+                    save_scope_as = curr_house
+
+                    set_global_variable = {
+                        name = temp_house
+                        value = scope:curr_house
+                    }
+
+                    set_house_name = "[GetGlobalVariable('temp_house').House.GetBaseNameNoTooltip]"
+
+                    remove_global_variable = temp_house
                 }
 
-                remove_global_variable = temp_char
             }
         }
     }

--- a/mp_name_fix/descriptor.mod
+++ b/mp_name_fix/descriptor.mod
@@ -1,4 +1,4 @@
-version="1.1"
+version="1.2"
 tags={
 	"Fixes"
 }

--- a/mp_name_fix/localization/english/mpnf_decision_l_english.yml
+++ b/mp_name_fix/localization/english/mpnf_decision_l_english.yml
@@ -1,6 +1,12 @@
 ﻿l_english:
- mpnf_decision: "Restore House Names"
- mpnf_decision_desc: "All living characters missing surnames will have their names restored.\n\nOne player must take this decision once all players have joined the multiplayer lobby."
- mpnf_decision_tooltip: "Restore the name of every [house|E] in the game."
- mpnf_decision_confirm: "Restore"
- mpnf_decision_custom.tt: "Rename every [house|E] to its current name."
+ mpnf_decision_save: "Save House Names"
+ mpnf_decision_save_desc: "This decision must be run prior to other players joining the lobby.\n\nSaves the currently working House names for later restoration by the 'Load House Names' decision."
+ mpnf_decision_save_tooltip: "Save the name of every [house|E] in the game for restoration."
+ mpnf_decision_save_custom_tt: "Save the name of every [house|E] in the game with currently living characters."
+ mpnf_decision_save_confirm: "Save"
+
+ mpnf_decision_load: "Load House Names"
+ mpnf_decision_load_desc: "This decision must be run after all players have joined the lobby, and the 'Save House Names' decision has already been taken.\n\n Restores the names of all Houses based on the values saved via the 'Save House Names' decision."
+ mpnf_decision_load_tooltip: "Restore the name of every [house|E] saved via Save House Names."
+ mpnf_decision_load_custom_tt: "Restore the name of every [house|E] in the game with currently living characters."
+ mpnf_decision_load_confirm: "Load"


### PR DESCRIPTION
Version 1.2 separates the mod into two decisions, one to store/save House names while they work, and one to load those working names once the UI inevitably breaks during multiplayer. This version is fully functional.